### PR TITLE
@alloy => Remove the CocoaPods from the front row extension

### DIFF
--- a/Emergence.xcodeproj/project.pbxproj
+++ b/Emergence.xcodeproj/project.pbxproj
@@ -28,8 +28,10 @@
 		60A4C4B21BCCEDC20092CC74 /* ServiceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A4C4B11BCCEDC20092CC74 /* ServiceProvider.swift */; };
 		60A4C4B61BCCEDC20092CC74 /* FrontPage.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 60A4C4AD1BCCEDC20092CC74 /* FrontPage.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		60A584731BCD69420006B8B4 /* ShowDataSource+Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A584721BCD69420006B8B4 /* ShowDataSource+Delegate.swift */; };
-		60B647EC1BCCF42C00908EE6 /* Artsy_Authentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60B647EA1BCCF42C00908EE6 /* Artsy_Authentication.framework */; };
-		60B647ED1BCCF42C00908EE6 /* Keys.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60B647EB1BCCF42C00908EE6 /* Keys.framework */; };
+		60A5847C1BCE449E0006B8B4 /* EmergenceKeys.m in Sources */ = {isa = PBXBuildFile; fileRef = 60A5847B1BCE449E0006B8B4 /* EmergenceKeys.m */; };
+		60A5847F1BCE45DE0006B8B4 /* Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A5847E1BCE45DE0006B8B4 /* Networking.swift */; };
+		60A584821BCE48D30006B8B4 /* ArtsyNetworkOperator.m in Sources */ = {isa = PBXBuildFile; fileRef = 60A584811BCE48D30006B8B4 /* ArtsyNetworkOperator.m */; };
+		60A584871BCE4CCD0006B8B4 /* ArtsyNetworkOperatorError.m in Sources */ = {isa = PBXBuildFile; fileRef = 60A584861BCE4CCD0006B8B4 /* ArtsyNetworkOperatorError.m */; };
 		60C390321BC29A5E002589E3 /* Partnerable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C390311BC29A5E002589E3 /* Partnerable.swift */; };
 		60C390341BC29AA3002589E3 /* Partner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C390331BC29AA3002589E3 /* Partner.swift */; };
 		60C3A6791BCD13D2003B0DE7 /* GCD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C3A6781BCD13D2003B0DE7 /* GCD.swift */; };
@@ -110,6 +112,14 @@
 		60A4C4B11BCCEDC20092CC74 /* ServiceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceProvider.swift; sourceTree = "<group>"; };
 		60A4C4B31BCCEDC20092CC74 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		60A584721BCD69420006B8B4 /* ShowDataSource+Delegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ShowDataSource+Delegate.swift"; sourceTree = "<group>"; };
+		60A5847A1BCE449E0006B8B4 /* EmergenceKeys.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EmergenceKeys.h; path = ../Pods/CocoaPodsKeys/EmergenceKeys.h; sourceTree = "<group>"; };
+		60A5847B1BCE449E0006B8B4 /* EmergenceKeys.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = EmergenceKeys.m; path = ../Pods/CocoaPodsKeys/EmergenceKeys.m; sourceTree = "<group>"; };
+		60A5847D1BCE44D20006B8B4 /* FrontPageBridgingHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrontPageBridgingHeader.h; sourceTree = "<group>"; };
+		60A5847E1BCE45DE0006B8B4 /* Networking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Networking.swift; sourceTree = "<group>"; };
+		60A584801BCE48D30006B8B4 /* ArtsyNetworkOperator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ArtsyNetworkOperator.h; path = "../Pods/Artsy+Authentication/Pod/Classes/ArtsyNetworkOperator.h"; sourceTree = "<group>"; };
+		60A584811BCE48D30006B8B4 /* ArtsyNetworkOperator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ArtsyNetworkOperator.m; path = "../Pods/Artsy+Authentication/Pod/Classes/ArtsyNetworkOperator.m"; sourceTree = "<group>"; };
+		60A584851BCE4CCD0006B8B4 /* ArtsyNetworkOperatorError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArtsyNetworkOperatorError.h; sourceTree = "<group>"; };
+		60A584861BCE4CCD0006B8B4 /* ArtsyNetworkOperatorError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ArtsyNetworkOperatorError.m; sourceTree = "<group>"; };
 		60B647EA1BCCF42C00908EE6 /* Artsy_Authentication.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Artsy_Authentication.framework; path = "Pods/../build/Debug-appletvos/Artsy_Authentication.framework"; sourceTree = "<group>"; };
 		60B647EB1BCCF42C00908EE6 /* Keys.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Keys.framework; path = "Pods/../build/Debug-appletvos/Keys.framework"; sourceTree = "<group>"; };
 		60C390311BC29A5E002589E3 /* Partnerable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Partnerable.swift; sourceTree = "<group>"; };
@@ -153,8 +163,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				60B647EC1BCCF42C00908EE6 /* Artsy_Authentication.framework in Frameworks */,
-				60B647ED1BCCF42C00908EE6 /* Keys.framework in Frameworks */,
 				60A4C4AF1BCCEDC20092CC74 /* TVServices.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -231,8 +239,10 @@
 		60A4C4B01BCCEDC20092CC74 /* FrontPage */ = {
 			isa = PBXGroup;
 			children = (
-				60A4C4B11BCCEDC20092CC74 /* ServiceProvider.swift */,
+				60A584841BCE48F00006B8B4 /* Extension */,
+				60A584831BCE48DE0006B8B4 /* Essentials from Pods */,
 				60A4C4B31BCCEDC20092CC74 /* Info.plist */,
+				60A5847D1BCE44D20006B8B4 /* FrontPageBridgingHeader.h */,
 			);
 			path = FrontPage;
 			sourceTree = "<group>";
@@ -243,6 +253,28 @@
 				60A584721BCD69420006B8B4 /* ShowDataSource+Delegate.swift */,
 			);
 			name = Subpages;
+			sourceTree = "<group>";
+		};
+		60A584831BCE48DE0006B8B4 /* Essentials from Pods */ = {
+			isa = PBXGroup;
+			children = (
+				60A5847A1BCE449E0006B8B4 /* EmergenceKeys.h */,
+				60A5847B1BCE449E0006B8B4 /* EmergenceKeys.m */,
+				60A584801BCE48D30006B8B4 /* ArtsyNetworkOperator.h */,
+				60A584811BCE48D30006B8B4 /* ArtsyNetworkOperator.m */,
+				60A584851BCE4CCD0006B8B4 /* ArtsyNetworkOperatorError.h */,
+				60A584861BCE4CCD0006B8B4 /* ArtsyNetworkOperatorError.m */,
+			);
+			name = "Essentials from Pods";
+			sourceTree = "<group>";
+		};
+		60A584841BCE48F00006B8B4 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				60A4C4B11BCCEDC20092CC74 /* ServiceProvider.swift */,
+				60A5847E1BCE45DE0006B8B4 /* Networking.swift */,
+			);
+			name = Extension;
 			sourceTree = "<group>";
 		};
 		60C3CB1B1BB14025005125EF = {
@@ -653,7 +685,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				60A5847F1BCE45DE0006B8B4 /* Networking.swift in Sources */,
+				60A584871BCE4CCD0006B8B4 /* ArtsyNetworkOperatorError.m in Sources */,
 				60A4C4B21BCCEDC20092CC74 /* ServiceProvider.swift in Sources */,
+				60A584821BCE48D30006B8B4 /* ArtsyNetworkOperator.m in Sources */,
+				60A5847C1BCE449E0006B8B4 /* EmergenceKeys.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -745,6 +781,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = net.artsy.shows.FrontPage;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = FrontPage/FrontPageBridgingHeader.h;
 			};
 			name = Debug;
 		};
@@ -761,6 +798,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = net.artsy.shows.FrontPage;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = FrontPage/FrontPageBridgingHeader.h;
 			};
 			name = Release;
 		};

--- a/Emergence.xcodeproj/xcuserdata/orta.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Emergence.xcodeproj/xcuserdata/orta.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -12,7 +12,7 @@
 		<key>FrontPage.xcscheme</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>21</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 	<key>SuppressBuildableAutocreation</key>

--- a/Emergence/Base.lproj/Main.storyboard
+++ b/Emergence/Base.lproj/Main.storyboard
@@ -72,30 +72,30 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="mhZ-dd-cBh">
                                         <rect key="frame" x="80" y="60" width="540" height="926"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Show Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L7d-cu-M94" propertyAccessControl="none">
-                                                <rect key="frame" x="0.0" y="0.0" width="540" height="49"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" text="Show Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L7d-cu-M94" propertyAccessControl="none">
+                                                <rect key="frame" x="0.0" y="0.0" width="540" height="56"/>
                                                 <fontDescription key="fontDescription" name="AGaramondPro-Regular" family="Adobe Garamond Pro" pointSize="48"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <view contentMode="scaleToFill" horizontalHuggingPriority="1" verticalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Swr-Hk-BBK">
-                                                <rect key="frame" x="0.0" y="55" width="540" height="762"/>
+                                            <view contentMode="scaleToFill" horizontalHuggingPriority="1" verticalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Swr-Hk-BBK">
+                                                <rect key="frame" x="0.0" y="62" width="540" height="748"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             </view>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="GALLERY NAME" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wEF-l9-cUy" customClass="ARSansSerifLabel">
-                                                <rect key="frame" x="0.0" y="823" width="540" height="31"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" text="GALLERY NAME" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wEF-l9-cUy" customClass="ARSansSerifLabel">
+                                                <rect key="frame" x="0.0" y="816" width="540" height="28"/>
                                                 <fontDescription key="fontDescription" name="AvantGardeGothicITCW01Dm" family="Avant Garde Gothic ITCW01Dm" pointSize="24"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="21st Nov - 23rd Dec" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Fo-4Y-ctp" customClass="ARSerifLabel">
-                                                <rect key="frame" x="0.0" y="860" width="540" height="30"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" text="21st Nov - 23rd Dec" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Fo-4Y-ctp" customClass="ARSerifLabel">
+                                                <rect key="frame" x="0.0" y="850" width="540" height="35"/>
                                                 <fontDescription key="fontDescription" name="AGaramondPro-Regular" family="Adobe Garamond Pro" pointSize="30"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Show location" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" highlighted="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qp9-O3-SYE" customClass="ARSerifLabel">
-                                                <rect key="frame" x="0.0" y="896" width="540" height="30"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" text="Show location" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" highlighted="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qp9-O3-SYE" customClass="ARSerifLabel">
+                                                <rect key="frame" x="0.0" y="891" width="540" height="35"/>
                                                 <fontDescription key="fontDescription" name="AGaramondPro-Regular" family="Adobe Garamond Pro" pointSize="30"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -168,17 +168,17 @@
                                                         <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="eGB-ju-x7E">
                                                             <rect key="frame" x="0.0" y="0.0" width="354" height="604"/>
                                                             <subviews>
-                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="1" verticalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="KXf-I7-Vsx">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="354" height="532"/>
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="1" verticalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KXf-I7-Vsx">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="354" height="522"/>
                                                                 </imageView>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Artist Name" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" highlighted="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Jh-DW-CUp" customClass="ARSerifLabel">
-                                                                    <rect key="frame" x="0.0" y="538" width="354" height="30"/>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Artist Name" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" highlighted="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Jh-DW-CUp" customClass="ARSerifLabel">
+                                                                    <rect key="frame" x="0.0" y="528" width="354" height="35"/>
                                                                     <fontDescription key="fontDescription" name="AGaramondPro-Regular" family="Adobe Garamond Pro" pointSize="30"/>
                                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Artwork name, date" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" highlighted="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E2c-bV-9oP" customClass="ARSerifLabel">
-                                                                    <rect key="frame" x="0.0" y="574" width="354" height="30"/>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Artwork name, date" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" highlighted="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E2c-bV-9oP" customClass="ARSerifLabel">
+                                                                    <rect key="frame" x="0.0" y="569" width="354" height="35"/>
                                                                     <fontDescription key="fontDescription" name="AGaramondPro-Regular" family="Adobe Garamond Pro" pointSize="30"/>
                                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                                     <nil key="highlightedColor"/>

--- a/FrontPage/ArtsyNetworkOperatorError.h
+++ b/FrontPage/ArtsyNetworkOperatorError.h
@@ -1,0 +1,5 @@
+// This is needed to compile the ArstyNetworkOperator
+
+#import <Foundation/Foundation.h>
+
+extern NSString *const ArtsyAuthenticationErrorDomain;

--- a/FrontPage/ArtsyNetworkOperatorError.m
+++ b/FrontPage/ArtsyNetworkOperatorError.m
@@ -1,0 +1,3 @@
+#import "ArtsyNetworkOperatorError.h"
+
+NSString* const ArtsyAuthenticationErrorDomain = @"ArtsyAuthenticationErrorDomain";

--- a/FrontPage/FrontPageBridgingHeader.h
+++ b/FrontPage/FrontPageBridgingHeader.h
@@ -1,0 +1,2 @@
+#import "EmergenceKeys.h"
+#import "ArtsyNetworkOperator.h"

--- a/FrontPage/Networking.swift
+++ b/FrontPage/Networking.swift
@@ -1,0 +1,21 @@
+import UIKit
+
+class Networking: NSObject {
+    static func auth(keys:EmergenceKeys, completion: (token: String?, error: NSError?)-> () ) {
+        let id = keys.artsyAPIClientKey()
+        let secret = keys.artsyAPIClientSecret()
+        let path = "https://api.artsy.net/api/v1/xapp_token?client_id=\(id)&client_secret=\(secret)"
+        let request = NSURLRequest(URL: NSURL(string:path)!)
+        let networking = ArtsyNetworkOperator()
+
+        networking.JSONTaskWithRequest(request, success: { request, response, data in
+            guard let data = data as? [String:AnyObject] else { return }
+            guard let token = data["xapp_token"] as? String else { return }
+            completion(token: token, error: nil)
+
+        }, failure: { request, response, error, json in
+            completion(token: nil, error: error)
+        })
+
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ LOCAL_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
 BRANCH = $(shell echo $(shell whoami)-$(shell git rev-parse --abbrev-ref HEAD))
 
 synxify:
-	bundle exec synx "$(SCHEME).xcodeproj"
+	bundle exec synx "$(SCHEME).xcodeproj" --exclusion "FrontPage/Essentials from Pods" 
 
 pr:
 	if [ "$(LOCAL_BRANCH)" == "master" ]; then echo "In master, not PRing"; else git push upstream "$(LOCAL_BRANCH):$(BRANCH)"; open "https://github.com/artsy/emergence/pull/new/artsy:master...$(BRANCH)"; fi


### PR DESCRIPTION
I opted for simplicity, and to have no need for extension frameworks. I only used pods for authentication and a HTTP client. I've used relative paths to take the core files out of the pods and to add them directly to the extension target. 

This means less code signing, less CP faffing, and less shared dependencies. Plus I could deploy to the app store, which is the biggest gain ;)
