### PR TITLE
@sarahscott => Use gemini for large image thumbnails when possible

### DIFF
--- a/Emergence.xcodeproj/project.pbxproj
+++ b/Emergence.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		60094A3D1BB9819C00016BB7 /* Observable+Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60094A3C1BB9819C00016BB7 /* Observable+Networking.swift */; };
 		60094A3F1BB99A9600016BB7 /* LocationsHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60094A3E1BB99A9600016BB7 /* LocationsHost.swift */; };
 		60094A431BB99AF500016BB7 /* cities.js in Resources */ = {isa = PBXBuildFile; fileRef = 60094A401BB99AF500016BB7 /* cities.js */; };
+		6036A23B1BCEA29C0090D5FC /* GeminiThumbnailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6036A23A1BCEA29C0090D5FC /* GeminiThumbnailable.swift */; };
 		608D650F1BCA675B00F749B8 /* NSDate+Ausstellungsdauer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608D650E1BCA675B00F749B8 /* NSDate+Ausstellungsdauer.swift */; };
 		608D65121BCA7F1600F749B8 /* Occupyable+isNotEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608D65111BCA7F1600F749B8 /* Occupyable+isNotEmpty.swift */; };
 		608D65141BCA803E00F749B8 /* SlideshowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608D65131BCA803E00F749B8 /* SlideshowView.swift */; };
@@ -98,6 +99,7 @@
 		60094A3C1BB9819C00016BB7 /* Observable+Networking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+Networking.swift"; sourceTree = "<group>"; };
 		60094A3E1BB99A9600016BB7 /* LocationsHost.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationsHost.swift; sourceTree = "<group>"; };
 		60094A401BB99AF500016BB7 /* cities.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = cities.js; sourceTree = "<group>"; };
+		6036A23A1BCEA29C0090D5FC /* GeminiThumbnailable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeminiThumbnailable.swift; sourceTree = "<group>"; };
 		608D650E1BCA675B00F749B8 /* NSDate+Ausstellungsdauer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDate+Ausstellungsdauer.swift"; sourceTree = "<group>"; };
 		608D65111BCA7F1600F749B8 /* Occupyable+isNotEmpty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Occupyable+isNotEmpty.swift"; sourceTree = "<group>"; };
 		608D65131BCA803E00F749B8 /* SlideshowView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SlideshowView.swift; sourceTree = "<group>"; };
@@ -352,6 +354,7 @@
 				60C3CB831BB14D95005125EF /* Imageable.swift */,
 				60E4A4D31BB54CA2002E43E0 /* Thumbnailable.swift */,
 				60C390311BC29A5E002589E3 /* Partnerable.swift */,
+				6036A23A1BCEA29C0090D5FC /* GeminiThumbnailable.swift */,
 			);
 			path = "Artsy Model Protocols";
 			sourceTree = "<group>";
@@ -714,6 +717,7 @@
 				608D650F1BCA675B00F749B8 /* NSDate+Ausstellungsdauer.swift in Sources */,
 				60C3CB811BB14D84005125EF /* AppContext.swift in Sources */,
 				60C3CB771BB14D50005125EF /* Artwork.swift in Sources */,
+				6036A23B1BCEA29C0090D5FC /* GeminiThumbnailable.swift in Sources */,
 				60094A3D1BB9819C00016BB7 /* Observable+Networking.swift in Sources */,
 				608D65221BCACE9700F749B8 /* ShowsOverviewViewController.swift in Sources */,
 				60C3A6791BCD13D2003B0DE7 /* GCD.swift in Sources */,

--- a/Emergence/Contexts/Presenting a Show/ShowDataSource+Delegate.swift
+++ b/Emergence/Contexts/Presenting a Show/ShowDataSource+Delegate.swift
@@ -61,11 +61,11 @@ class CollectionViewDelegate <T>: NSObject, ARCollectionViewMasonryLayoutDelegat
         guard let item = artworkDataSource.itemForIndexPath(indexPath) else { return }
         guard let image = imageForItem(item) else { return }
 
-        if let cell = cell as? ImageCollectionViewCell, let url = image.bestAvailableThumbnailURL() {
+        if let cell = cell as? ImageCollectionViewCell, let url = image.bestThumbnailWithHeight(dimensionLength) {
             cell.image.sd_setImageWithURL(url)
         }
 
-        if let cell = cell as? ArtworkCollectionViewCell, let artwork = item as? Artwork, let url = image.bestAvailableThumbnailURL() {
+        if let cell = cell as? ArtworkCollectionViewCell, let artwork = item as? Artwork, let url = image.bestThumbnailWithHeight(dimensionLength) {
             cell.artistNameLabel.text = artwork.oneLinerArtist()
             cell.titleLabel.text = artwork.title
             cell.image.sd_setImageWithURL(url)

--- a/Emergence/Info.plist
+++ b/Emergence/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3</string>
+	<string>0.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Emergence/Models/Artsy Model Protocols/GeminiThumbnailable.swift
+++ b/Emergence/Models/Artsy Model Protocols/GeminiThumbnailable.swift
@@ -1,0 +1,32 @@
+// Gemini is our image processing tool
+// because it is inhouse we can use it to provide
+// larger thumbnails for images like our install shots
+
+import Foundation
+
+let geminiServerAddress = "d7hftxdivxxvm.cloudfront.net"
+
+protocol GeminiThumbnailable {
+    var geminiToken: String? { get }
+}
+
+extension GeminiThumbnailable {
+
+    /// Returns a NSURL represnting a thumbnail using Gemini to process the image 
+    /// to the size we want based on the height of the image
+
+    func geminiThumbnailURLWithHeight(height:Int, quality:Int = 85) -> NSURL? {
+        guard let token = geminiToken else { return nil }
+        let string = "https://\(geminiServerAddress)/?resize_to=height&height=\(height)&quality=\(quality)&token=\(token)"
+        return NSURL(string: string)!
+    }
+
+    /// Returns a NSURL represnting a thumbnail using Gemini to process the image
+    /// to the size we want based on the width of the image
+
+    func geminiThumbnailURLWithWidth(width:Int, quality:Int = 85) -> NSURL? {
+        guard let token = geminiToken else { return nil }
+        let string = "https://\(geminiServerAddress)/?resize_to=width&width=\(width)&quality=\(quality)&token=\(token)"
+        return NSURL(string: string)!
+    }
+}

--- a/Emergence/Models/Artsy Model Protocols/Imageable.swift
+++ b/Emergence/Models/Artsy Model Protocols/Imageable.swift
@@ -12,13 +12,6 @@ protocol Imageable {
     var isDefault: Bool { get }
 }
 
-/// Extends the Imageable protocol with image URL handling
-
-extension Imageable {
-   
-}
-
-
 protocol ImageTileable {
     var tileBaseURL: NSURL { get }
     var tileSize: Int { get }

--- a/Emergence/Models/Electric Objects/Image.swift
+++ b/Emergence/Models/Electric Objects/Image.swift
@@ -2,14 +2,22 @@ import Gloss
 import Foundation
 import CoreGraphics
 
-struct Image: Imageable, ImageURLThumbnailable {
+struct Image: Imageable, ImageURLThumbnailable, GeminiThumbnailable  {
     let id: String
     let imageFormatString: String
     let imageVersions: [String]
     let imageSize: CGSize
     let aspectRatio: CGFloat?
+    let geminiToken: String?
 
     let isDefault: Bool
+
+    func bestThumbnailWithHeight(height:CGFloat) -> NSURL? {
+        if let url = geminiThumbnailURLWithHeight(Int(height)) {
+            return url
+        }
+        return bestAvailableThumbnailURL()
+    }
 }
 
 extension Image: Decodable {
@@ -26,6 +34,7 @@ extension Image: Decodable {
         id = idValue
         imageFormatString = imageFormatStringValue
         imageVersions = imageVersionsValue
+        geminiToken = "gemini_token" <~~ json
 
         imageSize = CGSize(width: "original_width" <~~ json ?? 1, height: "original_height" <~~ json ?? 1)
         aspectRatio = "aspect_ratio" <~~ json

--- a/FrontPage/Info.plist
+++ b/FrontPage/Info.plist
@@ -36,5 +36,9 @@
 		<key>NSExtensionPrincipalClass</key>
 		<string>$(PRODUCT_MODULE_NAME).ServiceProvider</string>
 	</dict>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
 </dict>
 </plist>

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ LOCAL_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
 BRANCH = $(shell echo $(shell whoami)-$(shell git rev-parse --abbrev-ref HEAD))
 
 synxify:
-	bundle exec synx "$(SCHEME).xcodeproj" --exclusion "FrontPage/Essentials from Pods" 
+	bundle exec synx "$(SCHEME).xcodeproj" --exclusion "FrontPage/Essentials from Pods"
 
 pr:
 	if [ "$(LOCAL_BRANCH)" == "master" ]; then echo "In master, not PRing"; else git push upstream "$(LOCAL_BRANCH):$(BRANCH)"; open "https://github.com/artsy/emergence/pull/new/artsy:master...$(BRANCH)"; fi


### PR DESCRIPTION
Creates a `GeminiThumbnailable` protocol which cares about whether something has a gemini token, then adds some extra functions to create thumbnails based on a max width/height.
