### PR TITLE
Remove city sections from the shows overview screen if they have no shows

### DIFF
--- a/Emergence/Contexts/Main Menu/Getting Shows/LocationBasedShowsEmitter.swift
+++ b/Emergence/Contexts/Main Menu/Getting Shows/LocationBasedShowsEmitter.swift
@@ -17,9 +17,9 @@ class LocationBasedShowEmitter: NSObject, ShowEmitter {
         self.title = location.name
     }
 
-    var updateBlock: EmitterUpdateCallback?
+    var updateBlocks = [EmitterUpdateCallback]()
     func onUpdate(callback: EmitterUpdateCallback) {
-        updateBlock = callback
+        updateBlocks.append(callback)
     }
 
     var shows:[Show] = []
@@ -53,7 +53,9 @@ class LocationBasedShowEmitter: NSObject, ShowEmitter {
             self.shows = self.shows + shows.filter({ $0.hasInstallationShots && $0.hasArtworks })
 
             if self.shows.isEmpty { print("Got no shows for \(self.location.name)") }
-            self.updateBlock?(shows: self.shows)
+            for block in self.updateBlocks {
+                block(shows: self.shows)
+            }
 
         }, error: { error in
             print("ERROROR \(error)")

--- a/Emergence/Contexts/Main Menu/Getting Shows/ShowEmitter.swift
+++ b/Emergence/Contexts/Main Menu/Getting Shows/ShowEmitter.swift
@@ -11,6 +11,14 @@ protocol ShowEmitter {
     func showAtIndexPath(index: NSIndexPath) -> Show
     func getShows()
     func onUpdate( callback: EmitterUpdateCallback )
+    
+    func isEqualTo(show: ShowEmitter) -> Bool
+}
+
+extension ShowEmitter {
+    func isEqualTo(show: ShowEmitter) -> Bool {
+        return title == show.title
+    }
 }
 
 class StubbyEmitter: NSObject, ShowEmitter {

--- a/Emergence/Contexts/Main Menu/ShowsOverviewViewController.swift
+++ b/Emergence/Contexts/Main Menu/ShowsOverviewViewController.swift
@@ -38,7 +38,13 @@ class ShowsOverviewViewController: UICollectionViewController, UICollectionViewD
         if cachedShows.isEmpty { featuredEmitter.getShows() }
 
         let otherEmitters:[ShowEmitter] = locationsHost.featured.map { locationID in
-            return LocationBasedShowEmitter(location: locationsHost[locationID]!, network: network)
+            let locationEmitter = LocationBasedShowEmitter(location: locationsHost[locationID]!, network: network)
+            locationEmitter.onUpdate({[weak locationEmitter] shows in
+                if let locationEmitter = locationEmitter where shows.count == 0 {
+                    self.removeEmitterAndSection(locationEmitter)
+                }
+            })
+            return locationEmitter
         }
 
         let featured:[ShowEmitter] = [featuredEmitter]
@@ -56,6 +62,15 @@ class ShowsOverviewViewController: UICollectionViewController, UICollectionViewD
         nav.viewControllers = nav.viewControllers.filter({ $0.isKindOfClass(AuthViewController) == false })
     }
 
+    func removeEmitterAndSection(emitter: ShowEmitter) {
+        guard let emitterIndex = emitters.indexOf(emitter.isEqualTo) else {
+            return
+        }
+        
+        emitters.removeAtIndex(emitterIndex)
+        collectionView?.deleteSections(NSIndexSet(index: emitterIndex))
+    }
+    
     func locationEmitterAtIndex(index: Int) -> LocationBasedShowEmitter? {
 
         // ignore the FeaturedShowEmitter

--- a/Podfile
+++ b/Podfile
@@ -23,7 +23,7 @@ def artsy_pods()
     if ENV['ARTSY_STAFF_MEMBER'] != nil || ENV['CI'] != nil
         pod 'Artsy+UIFonts', :git => "https://github.com/artsy/Artsy-UIFonts.git", :branch => "old_fonts_new_lib_tv"
     else
-        pod 'Artsy+OSSUIFonts'
+        pod 'Artsy+OSSUIFonts', :git => "https://github.com/artsy/Artsy-OSSUIFonts"
     end
 end
 


### PR DESCRIPTION
12:21] marin: re tv app @orta - I can see cities in the list that have no shows
[12:21] marin: e.g. the list of shows just ends saying Tokyo and nothing more
[12:21] orta: yeah, rather lazily I’ve not bothered removing them :smile:
[12:22] orta: I think I have an issue for it, but shippers gotta ship
[12:22] marin: should I send you a PR?
[12:22] marin: :stuck_out_tongue:
[12:22] marin: though it might be faster to fix it yourself than to merge a PR for it :simple_smile:
[12:40] orta: you sure can send a PR :simple_smile:
[12:40] orta: I’m not touching that codebase for a little bit, so it’s free to edit

---

11:21] marin: @orta: I got to know and understand the code and I could fix the issue in few different ways, but I guess I need to know what the expected behavior is; you said there was a ticket for it ?
[11:23] marin: also are the emitters expected to emit entities more times? like … if there aren’t any shows in Tokyo, could there be a signal that brings in some shows while the user has the app open ?
[13:48] orta: I feel like if an emitter has no shows at all, it should be removed from the list of emitters
[13:48] orta: no point in trying to make a “no shows” kind of default
